### PR TITLE
Removed duration parameter from Round Begun

### DIFF
--- a/CS-Jukebox/GameLogic.cs
+++ b/CS-Jukebox/GameLogic.cs
@@ -92,7 +92,7 @@ namespace CS_Jukebox
             {
                 jukebox.Stop();
                 musicState = MusicState.Live;
-                jukebox.PlaySong(Properties.SelectedKit.startSong, false, 8);
+                jukebox.PlaySong(Properties.SelectedKit.startSong, false);
                 Console.WriteLine("Round Begun");
 
             }


### PR DESCRIPTION
I removed the duration parameter from the Round Start song to let the user decide the duration themselves. Ideally, this would be handled by a seperate slider in the GUI, but that isn't really a priority I would assume.

Also, in my testing, the Round Start song ended earlier than the 8 seconds specified (It ended after around 1 second). I did not find the cause of that issue, or if it is an issue entirely on my side.